### PR TITLE
Add arm platform

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -62,6 +62,9 @@ jobs:
             type=semver,pattern={{version}}
             type=raw,value=latest
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -74,7 +74,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
+          platforms: linux/amd64,linux/arm64
 
       # Sign the resulting Docker image digest except on PRs.
       # This will only write to the public Rekor transparency log when the Docker

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-16-cores
     permissions:
       contents: read
       packages: write

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,7 @@ FROM rust:buster as build
 RUN apt-get update && apt-get install --yes libpq-dev wget
 
 #add scache to speed up builds
-RUN wget https://github.com/mozilla/sccache/releases/download/v0.3.0/sccache-v0.3.0-x86_64-unknown-linux-musl.tar.gz \
-    && tar xzf sccache-v0.3.0-x86_64-unknown-linux-musl.tar.gz \
-    && mv sccache-v0.3.0-x86_64-unknown-linux-musl/sccache /usr/local/bin/sccache \
-    && chmod +x /usr/local/bin/sccache
+RUN cargo install sccache
 
 RUN cargo install cargo-prefetch
 RUN cargo prefetch


### PR DESCRIPTION
M1 builds have become really slow. I think the issue is that when we switched to using our own build image, we forced the build to run on amd64 and so require slow emulation on M1. This PR additionally builds an arm64 image for `rust-sscache`. It doesn't appear that there are official binaries for sscache for arm64, so I changed it to build from source. It's slow (~30 minutes) to build because it has to use emulation, but we won't have to build this frequently.